### PR TITLE
nx.draw_networkx_edges() does not show matplotlib figure

### DIFF
--- a/causalAssembly/models_dag.py
+++ b/causalAssembly/models_dag.py
@@ -1457,6 +1457,8 @@ class ProductionLineGraph:
             connectionstyle="arc3,rad=0.3",
         )
 
+	plt.show()
+
     def __str__(self):
         s = "ProductionLine\n\n"
         for cell in self.cells:


### PR DESCRIPTION
This pull request addresses an issue where calling _nx.draw_networkx_edges_ does not display the Matplotlib figure as expected. The problem was identified during _example_line.show()_.

Changes Made:
- Added `plt.show()` at the end of the plotting sequence to ensure that the figure is rendered and displayed to the user.

How to Test:
- Run the updated code with a sample graph and verify that the Matplotlib window opens displaying the graph with its edges properly rendered.

By merging this pull request, users will be able to visualize their network graphs with edges displayed correctly, thanks to the explicit call to `plt.show()` which triggers the rendering of the figure.

Best, Lukas